### PR TITLE
bugfix: actually return 3 elements from getBosses

### DIFF
--- a/src/chatcommands/breakpoint.js
+++ b/src/chatcommands/breakpoint.js
@@ -147,7 +147,7 @@ function getBosses(attacker) {
             bosses.push(boss);
         }
     }
-    return bosses.slice(Math.max(bosses.length - 3, 1)); // return last 3 elements
+    return bosses.slice(-3); // return last 3 elements
 }
 
 const getBreakpoint = (data, message) => {

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -59,6 +59,7 @@ describe('Acceptance Chat Commands', () => {
 			let msg = Object.assign(fakeMessage, {content: '!bp alakazam future_sight 15'});
 			sendMessage(msg, (result) => {
 				assert(result.indexOf('FUTURE SIGHT damage against Venusaur\nLv20:   103') > -1);
+				assert(result.match(/damage against/g).length >= 3);
 				done();
 			});
 		});


### PR DESCRIPTION
This fixes a minor bug, where instead of returning 3 bosses that the selected Pokemon counters, 2 were being returned. `Array.slice(-3)` did the trick. Added a test too.