### PR TITLE
Add .editorconfig to help enforce tabs for .js, spaces for .json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*.js]
+indent_style = tab
+
+[*.json]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
See http://editorconfig.org/#overview for details, but tl;dr is this
enables configured editors to insert tabs instead of spaces for .js
and spaces instead of tabs for .json, to be consistent with current
conventions, without requiring developers to override their global
settings or enabling insecure local overrides.