### PR TITLE
Add neighborhood and subregion mappings to regions.json

### DIFF
--- a/config/regions.json
+++ b/config/regions.json
@@ -11,5 +11,20 @@
     "eastbay",
     "sacramento",
     "allregions"
-  ]
+  ],
+  "region_subregions": {
+    "sf": ["eastsf", "centralsf", "westsf"],
+    "allregions": ["eastsf", "centralsf", "westsf", "southsf", "peninsula", "sanjose", "marin", "eastbay", "sacramento"]
+  },
+  "region_neighborhoods": {
+    "eastsf": ["embarcadero-p39-northbeach", "missionbay-dogpatch", "soma-ferry_bldg", "fidi-union_sq", "tenderloin-civic_center", "nob-russian_hill"],
+    "centralsf": ["haight-castro", "mission-dolores", "fillmore-hayes_valley"],
+    "westsf": ["presidio-marina", "richmond-gg_park", "sunset-", "lakeview-lake_merced"],
+    "southsf": ["glen_park-twin_peaks", "ingleside-", "excelsior-portola", "outer_mission-cow_palace", "bayview-", "south_city-brisbane", "daly_city-pacifica"],
+    "peninsula": ["half_moon_bay-coast", "san_bruno-burlingame", "san_mateo-foster_city", "belmont-sc-rws", "redwood_city-palo_alto", "mt-view_sunnyvale"],
+    "sanjose": ["san-jose"],
+    "marin": ["marin-"],
+    "eastbay": ["oakland-", "berkeley-", "east-bay"],
+    "sacramento": ["sacramento-"]
+  }
 }


### PR DESCRIPTION
Add two new (currently unused) subkeys to regions.json:

- region_subregions: these regions should not have a gymraids_ channel,
  but should instead be superregions that consist of all neighborhoods
  and gymraids_ channels for the listed child regions

- region_neighborhoods: mapping of region to neighborhood name.
  Neighborhoods must contain a "-".