### PR TITLE
Add Attack command, make argument order more user friendly

### DIFF
--- a/src/chatcommands/attack.js
+++ b/src/chatcommands/attack.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/* eslint-disable */
+
+const CONSTANTS = require('./../constants');
+const damage = require('../util/damage.js');
+const pokemon = require('../../data/pokemon.json');
+const moves = require('../../data/moves.json');
+
+const usage = 'Command usage: **!attack attacker level attack_name iv defender level iv**\nExample: !attack machamp 20 counter 15 blissey 30 12';
+
+const getDamage = (data, message) => {
+    let reply = '';
+    const msgSplit = message.content.toLowerCase().split(" ");
+    if (!msgSplit || msgSplit.length < 4) {
+        reply = 'Sorry, incorrect format.\n'+usage;
+        message.channel.send(reply);
+        return reply;
+    }
+    // let's be smart because the order of arguments is hard to remember.
+    let words = []; // word order should naturally be: attacker, attack, defender
+    let numbers = []; // numbers are IVs if <=15, and level if 20<=number<=40
+    for (var i=1; i<msgSplit.length; i++) {
+        if (isNaN(msgSplit[i])) {
+            words.push(msgSplit[i]);
+        }
+        else {
+            numbers.push(msgSplit[i]);
+        }
+    }
+    if (words.length < 3) {
+        reply = 'Sorry, incorrect format.\n'+usage;
+        message.channel.send(reply);
+        return reply;
+    }
+    const attacker = CONSTANTS.standardizePokemonName(words[0]);
+    const move = words[1];
+    const defender = CONSTANTS.standardizePokemonName(words[2]);
+    if (!pokemon[attacker.toUpperCase()] ||
+        !pokemon[defender.toUpperCase()] ||
+        !moves[move.toUpperCase()]) {
+            reply = 'Sorry, incorrect format.\n'+usage;
+            message.channel.send(reply);
+            return reply;
+    }
+    let attackerLevel = 0;
+    let attackIV = 0;
+    let defenderLevel = 0;
+    let defenseIV = 0;
+
+    // pick out IVs/level based on whether arguments <=15 (IV) or >=20 (level)
+    for (var i=0; i<numbers.length; i++) {
+        if (numbers[i] >= 20 && numbers[i] <= 40) {
+            if (attackerLevel == 0 &&
+                    msgSplit.indexOf(numbers[i]) < msgSplit.indexOf(defender.toLowerCase())) {
+                attackerLevel = numbers[i];
+            }
+            else {
+                defenderLevel = numbers[i];
+            }
+        }
+        else if (numbers[i] >= 0 && numbers[i] <= 15) {
+            if (attackIV == 0 &&
+                    msgSplit.indexOf(numbers[i]) < msgSplit.indexOf(defender.toLowerCase())) {
+                attackIV = numbers[i];
+            }
+            else {
+                defenseIV = numbers[i];
+            }
+        }
+    }
+    // set any necessary defaults
+    if (attackerLevel == 0) { attackerLevel = 20; }
+    if (attackIV == 0) { attackIV = 15; }
+    if (defenderLevel == 0) { defenderLevel = 20; }
+    if (defenseIV == 0) { defenseIV = 15; }
+
+    reply = "```Attacker: "+attacker.capitalize()+" (Lv"+attackerLevel+") (Attack IV: "+attackIV+")\n";
+    reply += "Defender: "+defender.capitalize()+" (Lv"+defenderLevel+") (Defense IV: "+defenseIV+")\n";
+    reply += move.toUpperCase().replace('_', ' ')+" does ";
+    reply += damage.calcDamage(attacker, attackerLevel, attackIV, move, defender, defenderLevel, defenseIV)
+    reply += " damage```";
+
+    message.channel.send(reply);
+    return reply;
+};
+
+module.exports = (data) => ( (message) => {
+    return getDamage(data, message);
+});

--- a/src/chatcommands/breakpoint.js
+++ b/src/chatcommands/breakpoint.js
@@ -4,77 +4,12 @@
 /* eslint-disable */
 
 const CONSTANTS = require('./../constants');
-
-const usage = 'Command usage: **!breakpoint attacker attack_name iv (optional: defender)**';
-const counters = require('../../data/counters.json');
-const levelToCPM = require('../../data/levelToCPM.json');
 const pokemon = require('../../data/pokemon.json');
 const moves = require('../../data/moves.json');
-const types = require('../../data/types.json');
+const counters = require('../../data/counters.json');
+const damage = require('../util/damage.js');
 
-function roundTo(num, digits) {
-    return +(Math.round(num + "e+"+digits)  + "e-"+digits);
-}
-
-function getDamage(attacker, iv, move, defender, level) {
-    attacker = attacker.toUpperCase();
-    move = move.toUpperCase();
-    defender = defender.toUpperCase();
-    var power = getPower(move);
-    var attack = getBaseStat(attacker, "attack");
-    var attackIV = iv;
-    var attackerCPM = getCPM(level);
-    var defense = getBaseStat(defender, "defense");
-    var defenseIV = 15;
-    var defenderCPM = getCPM(40);
-    var STAB = getSTAB(move, attacker);
-    var effectiveness = getEffectiveness(move, defender);
-    return Math.floor(0.5 * power * ((attack+attackIV) * attackerCPM) / ((defense+defenseIV) * defenderCPM) * STAB * effectiveness) + 1;
-}
-
-function getPower(move) {
-    return moves[move]["power"];
-}
-
-function getBaseStat(name, stat) {
-    return pokemon[name]["stats"][stat];
-}
-
-function getCPM(level) {
-    return roundTo(levelToCPM[level.toString()], 3);
-}
-
-function getSTAB(move, attacker) {
-    var type = moves[move]["type"];
-    if (pokemon[attacker]["types"].indexOf(type) >= 0) {
-        return 1.2;
-    }
-    return 1.0;
-}
-
-function getEffectiveness(move, defender) {
-    var moveInfo = moves[move];
-    var moveType = moveInfo["type"];
-    var defenderInfo = pokemon[defender];
-    var defenderTypes = defenderInfo["types"];
-    var multiplier = 1.0;
-    for (var i=0; i<defenderTypes.length; i++) {
-        var defenderType = defenderTypes[i];
-        // check if it's super effective
-        if (types[moveType]["se"].indexOf(defenderType) >= 0) {
-            multiplier *= 1.4;
-        }
-        // check if it's not very effective
-        else if (types[moveType]["nve"].indexOf(defenderType) >= 0) {
-            multiplier *= 0.714;
-        }
-        // check if defender is "immune"
-        else if (types[moveType]["immune"].indexOf(defenderType) >= 0) {
-            multiplier *= 0.714 * 0.714;
-        }
-    }
-    return multiplier;
-}
+const usage = 'Command usage: **!breakpoint attacker attack_name iv (optional: defender)**';
 
 function calcBreakpoint(attacker, move, iv, defender) {
     attacker = attacker.toUpperCase();
@@ -92,11 +27,11 @@ function calcBreakpoint(attacker, move, iv, defender) {
     var reply = "";
     var breakpoints = {};
     if (!pokeInfo) {
-    	reply = 'Sorry, I can\'t find that pokemon. Remember to enter the pokemon\'s exact name in the pokedex.\n'+usage;
+        reply = 'Sorry, I can\'t find that pokemon. Remember to enter the pokemon\'s exact name in the pokedex.\n'+usage;
         return reply;
     }
     if (!moveInfo) {
-    	reply = 'Sorry, I can\'t find that move. Remember to replace spaces with _ when typing a move.\n'+usage;
+        reply = 'Sorry, I can\'t find that move. Remember to replace spaces with _ when typing a move.\n'+usage;
         return reply;
     }
     for (var index in bosses) {
@@ -108,32 +43,31 @@ function calcBreakpoint(attacker, move, iv, defender) {
         breakpoints[defender] = {}
         reply += move.replace("_", " ")+" damage against "+defender.capitalize()+"\n";
 
-        var currentMaxDamage = getDamage(attacker, iv, move, defender, 20);
+        var currentMaxDamage = damage.calcDamage(attacker, 20, iv, move, defender, 40, 20);
         breakpoints[defender][20] = currentMaxDamage;
         for (var level=20; level<40; level+=0.5) {
-            var damage = getDamage(attacker.toUpperCase(), iv, move, defender.toUpperCase(), level);
-            if (damage > currentMaxDamage) {
-                breakpoints[defender][level] = damage;
-                currentMaxDamage = damage;
+            var currentDamage = damage.calcDamage(attacker, level, iv, move, defender, 40, 15);
+            if (currentDamage > currentMaxDamage) {
+                breakpoints[defender][level] = currentDamage;
+                currentMaxDamage = currentDamage;
             }
         }
         var sortedKeys = Object.keys(breakpoints[defender]).sort();
         for (var i=0; i<sortedKeys.length; i++) {
             var level = parseFloat(sortedKeys[i]);
-            var damage = breakpoints[defender][level];
             var separator = (level % 1 == 0) ? ":   " : ": "; // add nice spacing for levels with .5
             reply += "Lv"+level+separator+breakpoints[defender][level];
             var percent = "";
             if (i > 0) {
                 // add a % increase calculation
                 var prevLevel = parseFloat(sortedKeys[i-1]);
-                percent = roundTo((1.0 * breakpoints[defender][level] / breakpoints[defender][prevLevel] - 1) * 100.0, 2);
+                percent = CONSTANTS.roundTo((1.0 * breakpoints[defender][level] / breakpoints[defender][prevLevel] - 1) * 100.0, 2);
                 reply += " (+"+percent+"%)"
             }
             reply += "\n";
         }
-        if (Object.keys(breakpoints[defender]).indexOf(39.5) == -1) {
-            reply = reply + "Lv39.5: "+getDamage(attacker, iv, move, defender, level);
+        if (Object.keys(breakpoints[defender]).indexOf("39.5") == -1) {
+            reply = reply + "Lv39.5: "+damage.calcDamage(attacker, level, iv, move, defender, 40, 15);
         }
         reply += "\n";
     }
@@ -151,31 +85,43 @@ function getBosses(attacker) {
 }
 
 const getBreakpoint = (data, message) => {
-	let reply = '';
-	const msgSplit = message.content.toLowerCase().split(" ");
-	if (!msgSplit || msgSplit.length < 4) {
+    let reply = '';
+    const msgSplit = message.content.toLowerCase().split(" ");
+    if (!msgSplit || msgSplit.length < 3) {
         reply = 'Sorry, incorrect format.\n'+usage;
         message.channel.send(reply);
         return reply;
     }
-	const attacker = CONSTANTS.standardizePokemonName(msgSplit[1]);
-    const move = msgSplit[2];
-    const iv = msgSplit[3]; // check for int 0-15
+    // let's be smart because the order of arguments is hard to remember.
+    let words = []; // word order should naturally be: attacker, attack, defender
+    let numbers = []; // attacker IV
+    for (var i=1; i<msgSplit.length; i++) {
+        if (isNaN(msgSplit[i])) {
+            words.push(msgSplit[i]);
+        }
+        else {
+            numbers.push(msgSplit[i]);
+        }
+    }
+    if (numbers.length == 0) { numbers.push('15'); }
+    const attacker = CONSTANTS.standardizePokemonName(words[0]);
+    const move = words[1];
+    const iv = numbers[0]; // check for int 0-15
     if (isNaN(iv) || iv > 15 || iv < 0) {
-		reply = "Sorry, IV must be 0-15.\n"+usage
+        reply = "Sorry, IV must be 0-15.\n"+usage
         message.channel.send(reply);
         return reply;
     }
     let defender = null; // specifying defender is optional
-    if (msgSplit.length >= 5) {
-        defender = CONSTANTS.standardizePokemonName(msgSplit[4]);
+    if (words.length >= 3) {
+        defender = CONSTANTS.standardizePokemonName(words[2]);
     }
     reply = calcBreakpoint(attacker, move, iv, defender);
     
-	message.channel.send(reply);
-	return reply;
+    message.channel.send(reply);
+    return reply;
 };
 
 module.exports = (data) => ( (message) => {
-	return getBreakpoint(data, message);
+    return getBreakpoint(data, message);
 });

--- a/src/chatrouter.js
+++ b/src/chatrouter.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const attack = require('./chatcommands/attack');
 const breakpoint = require('./chatcommands/breakpoint');
 const checkNew = require('./chatcommands/checkNew');
 const counters = require('./chatcommands/counters');
@@ -14,6 +15,7 @@ const want = require('./chatcommands/want');
 
 module.exports = (data) => {
 	return {
+		attack: attack(data),
 		breakpoint: breakpoint(data),
 		checkNew: checkNew(data),
 		counters: counters(data),

--- a/src/client.js
+++ b/src/client.js
@@ -94,8 +94,9 @@ client.on('message', (message, cb) => {
 		message.channel.send(message.member.displayName + ', you may only run this command in the ' + channelsByName['professor_redwood'] + ' channel');
 		return;
 	}
-
-	if (command === '!breakpoint' || command === '!bp') {return cb(CHATCOMMANDS.breakpoint(message));}
+	if (command === '!attack' || command === '!atk' ||
+		command === '!damage' || command === '!dmg') {return cb(CHATCOMMANDS.attack(message));}
+	else if (command === '!breakpoint' || command === '!bp') {return cb(CHATCOMMANDS.breakpoint(message));}
 	else if (command === '!cp') {return cb(CHATCOMMANDS.cp(message));}
 	else if (command === '!counter' || command === '!counters') {return cb(CHATCOMMANDS.counters(message));}
 	else if (command === '!help') {return cb(CHATCOMMANDS.help(message));}

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,10 @@ const alphanumeric = (inputtxt) => {
 	return (inputtxt.value && inputtxt.value.match(letterNumber));
 };
 
+const roundTo = (num, digits) => {
+    return +(Math.round(num + "e+"+digits)  + "e-"+digits);
+}
+
 //Function and vars for sanitizing input
 const tagBody = '(?:[^"\'>]|"[^"]*"|\'[^\']*\')*';
 
@@ -56,5 +60,6 @@ const standardizePokemonName = (name) => {
 
 //make this more elegant when we have more than one
 data.standardizePokemonName = standardizePokemonName;
+data.roundTo = roundTo;
 
 module.exports = data;

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -68,6 +68,54 @@ describe('Acceptance Chat Commands', () => {
 
 	//wrong channel commands - check new
 
+	describe('!attack', () => {
+		it('snorlax', (done) => {
+			let validCommands = ["!dmg 15 20 snorlax hyper_beam 20 mewtwo 15",
+								 "!dmg 20 15 snorlax hyper_beam 20 mewtwo 15",
+								 "!dmg 15 snorlax 20 hyper_beam 20 mewtwo 15",
+								 "!dmg snorlax 20 15 hyper_beam 20 mewtwo 15",
+								 "!dmg snorlax 20 hyper_beam 15 20 mewtwo 15",
+								 "!dmg snorlax 20 hyper_beam 15 15 20 mewtwo",
+								 "!dmg snorlax 20 hyper_beam 15 20 mewtwo 15",
+								 "!dmg snorlax 20 hyper_beam 15 mewtwo 15 20",
+								 "!dmg snorlax 20 hyper_beam 15 mewtwo 20",
+								 "!dmg snorlax 20 hyper_beam 15 mewtwo",
+								 "!dmg snorlax 20 hyper_beam mewtwo",
+								 "!dmg snorlax hyper_beam 15 mewtwo",
+								 "!dmg 15 snorlax hyper_beam mewtwo",
+								 "!dmg snorlax hyper_beam mewtwo",
+								 "!dmg snorlax 30 30 30 30 30 hyper_beam mewtwo"];
+			validCommands.forEach(function(cmd) {
+				let msg = Object.assign(fakeMessage, {content: cmd});
+				sendMessage(msg, (result) => {
+					assert(result.indexOf('HYPER BEAM does 94 damage') > -1);
+				});
+			});
+			done();
+		});
+		it('bad attacker', (done) => {
+			let msg = "!dmg snorkachu hyper_beam mewtwo"
+			sendMessage(msg, (result) => {
+				assert(result.indexOf('Sorry, incorrect format.') > -1);
+				done();
+			});
+		});
+		it('bad defender', (done) => {
+			let msg = "!dmg snorlax 30 30 30 30 30 hyper_beam"
+			sendMessage(msg, (result) => {
+				assert(result.indexOf('Sorry, incorrect format.') > -1);
+				done();
+			});
+		});
+		it('bad move', (done) => {
+			let msg = "!dmg snorlax 30 30 30 30 30 hyper_butt mewtwo"
+			sendMessage(msg, (result) => {
+				assert(result.indexOf('Sorry, incorrect format.') > -1);
+				done();
+			});
+		});
+	});
+
 	describe('!breakpoint', () => {
 		it('golem', (done) => {
 			let msg = Object.assign(fakeMessage, {content: '!breakpoint golem rock_throw 15'});

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -70,21 +70,21 @@ describe('Acceptance Chat Commands', () => {
 
 	describe('!attack', () => {
 		it('snorlax', (done) => {
-			let validCommands = ["!dmg 15 20 snorlax hyper_beam 20 mewtwo 15",
-								 "!dmg 20 15 snorlax hyper_beam 20 mewtwo 15",
-								 "!dmg 15 snorlax 20 hyper_beam 20 mewtwo 15",
-								 "!dmg snorlax 20 15 hyper_beam 20 mewtwo 15",
-								 "!dmg snorlax 20 hyper_beam 15 20 mewtwo 15",
-								 "!dmg snorlax 20 hyper_beam 15 15 20 mewtwo",
-								 "!dmg snorlax 20 hyper_beam 15 20 mewtwo 15",
-								 "!dmg snorlax 20 hyper_beam 15 mewtwo 15 20",
-								 "!dmg snorlax 20 hyper_beam 15 mewtwo 20",
-								 "!dmg snorlax 20 hyper_beam 15 mewtwo",
-								 "!dmg snorlax 20 hyper_beam mewtwo",
-								 "!dmg snorlax hyper_beam 15 mewtwo",
-								 "!dmg 15 snorlax hyper_beam mewtwo",
-								 "!dmg snorlax hyper_beam mewtwo",
-								 "!dmg snorlax 30 30 30 30 30 hyper_beam mewtwo"];
+			let validCommands = ["!attack 15 20 snorlax hyper_beam 20 mewtwo 15",
+								 "!attack 20 15 snorlax hyper_beam 20 mewtwo 15",
+								 "!attack 15 snorlax 20 hyper_beam 20 mewtwo 15",
+								 "!attack snorlax 20 15 hyper_beam 20 mewtwo 15",
+								 "!attack snorlax 20 hyper_beam 15 20 mewtwo 15",
+								 "!attack snorlax 20 hyper_beam 15 15 20 mewtwo",
+								 "!attack snorlax 20 hyper_beam 15 20 mewtwo 15",
+								 "!attack snorlax 20 hyper_beam 15 mewtwo 15 20",
+								 "!attack snorlax 20 hyper_beam 15 mewtwo 20",
+								 "!attack snorlax 20 hyper_beam 15 mewtwo",
+								 "!attack snorlax 20 hyper_beam mewtwo",
+								 "!attack snorlax hyper_beam 15 mewtwo",
+								 "!attack 15 snorlax hyper_beam mewtwo",
+								 "!attack snorlax hyper_beam mewtwo",
+								 "!attack snorlax 30 30 30 30 30 hyper_beam mewtwo"];
 			validCommands.forEach(function(cmd) {
 				let msg = Object.assign(fakeMessage, {content: cmd});
 				sendMessage(msg, (result) => {
@@ -94,21 +94,21 @@ describe('Acceptance Chat Commands', () => {
 			done();
 		});
 		it('bad attacker', (done) => {
-			let msg = "!dmg snorkachu hyper_beam mewtwo"
+			let msg = Object.assign(fakeMessage, {content: '!attack snorkachu hyper_beam mewtwo'});
 			sendMessage(msg, (result) => {
 				assert(result.indexOf('Sorry, incorrect format.') > -1);
 				done();
 			});
 		});
 		it('bad defender', (done) => {
-			let msg = "!dmg snorlax 30 30 30 30 30 hyper_beam"
+			let msg = Object.assign(fakeMessage, {content: '!attack snorlax 30 30 30 30 30 hyper_beam'});
 			sendMessage(msg, (result) => {
 				assert(result.indexOf('Sorry, incorrect format.') > -1);
 				done();
 			});
 		});
 		it('bad move', (done) => {
-			let msg = "!dmg snorlax 30 30 30 30 30 hyper_butt mewtwo"
+			let msg = Object.assign(fakeMessage, {content: '!attack snorlax 30 30 30 30 30 hyper_butt mewtwo'});
 			sendMessage(msg, (result) => {
 				assert(result.indexOf('Sorry, incorrect format.') > -1);
 				done();
@@ -157,8 +157,8 @@ describe('Acceptance Chat Commands', () => {
 		it('bad iv letters', (done) => {
 			let msg = Object.assign(fakeMessage, {content: '!bp alakazam future_sight zzzzz'});
 			sendMessage(msg, (result) => {
-				assert(result.indexOf('Sorry, IV must be 0-15.\nCommand usage: **!breakpoint attacker attack_name iv (optional: defender)**') > -1);
-				done();
+				assert(result.indexOf('Sorry, I can\'t find that defender. Remember to enter the pokemon\'s exact name in' +
+						' the pokedex.\nCommand usage: **!breakpoint attacker attack_name iv (optional: defender)**') > -1);				done();
 			});
 		});
 		it('bad move', (done) => {


### PR DESCRIPTION
This adds damage calculations, accessible by any of the following commands:
```
!attack
!atk
!damage
!dmg
```

Argument order is very flexible. The following are all equivalent:
```
!dmg mewtwo 20 confusion 15 machamp 20 15
!dmg 15 20 mewtwo confusion 15 20 machamp
!dmg mewtwo 20 15 confusion 15 20 machamp
!dmg mewtwo confusion machamp
```

I added some of the flexibility to the `!bp` command as well.
Also added tests.

This was a long time in the making, and it's very possible I've screwed something up, although I tried to break it in every way I could think of. Please do let me know if there's anything to change!