### PR TITLE
Replace multiple spaces with single space

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -73,6 +73,8 @@ client.on('message', (message, cb) => {
 	
 	let reply = '';
 	const command = message.content.split(' ')[0].toLowerCase();
+	// replace any multiple spaces with a single space
+	while (message.content.indexOf('  ') > -1) {message.content = message.content.replace('  ', ' ');}
 
 	if (message.member && command !== '!play')	{CHATCOMMANDS.checkNew(message);}
 


### PR DESCRIPTION
Sometimes people accidentally put more than 1 space in their bot commands. This screws things up since we use `.split(' ')`, on a single space.

This PR just replaces any multiple spaces with 1 space, tada