### PR TITLE
add ability to read raid info from raid boss image

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "dependencies": {
     "discord.js": "^11.1.0",
     "mocha": "^3.5.0",
+    "moment": "^2.18.1",
     "mysql": "^2.14.0"
+    "opencv": "^6.0.0",
+    "request": "^2.81.0",
+    "tesseract.js": "^1.0.10"
   },
   "devDependencies": {
     "eslint": "^4.3.0"

--- a/src/chatcommands/raidimage.js
+++ b/src/chatcommands/raidimage.js
@@ -1,0 +1,267 @@
+var cv = require('opencv')
+var Tesseract = require('tesseract.js')
+var moment = require('moment')
+var request = require('request')
+
+var debugfile = 1
+var DEBUG = false
+
+var MORPH_RECT = 0
+var MORPH_CROSS = 1
+var MORPH_ELLIPSE = 2 
+
+function ImageProcessor(img) {
+  this.img = img
+  this.debugindex = debugfile++
+}
+
+ImageProcessor.prototype.copy = function(deep) {
+  var copied = deep ? this.img.clone() : this.img
+  return new ImageProcessor(copied)
+}
+
+ImageProcessor.prototype.removeAlpha = function() {
+  if (this.img.channels() > 3) {
+    var channels = this.img.split()
+    this.img = new cv.Matrix(this.img.height(), this.img.width(), cv.Constants.CV_32F)
+    this.img.merge([channels[0],channels[1],channels[2]])
+  }
+
+  return this
+}
+
+ImageProcessor.prototype.grayscale = function() {
+  var dest = new cv.Matrix(this.img.height(), this.img.width(), cv.Constants.CV_8UC1)
+  this.img.convertTo(dest, cv.Constants.CV_8UC1)
+  dest.convertGrayscale()
+  this.img = dest
+  return this
+}
+
+ImageProcessor.prototype.blackwhite = function(offset) {
+  //this.img.convertGrayscale()
+  var max = this.img.minMaxLoc()
+  if (!offset) offset = 5
+
+  this.img = this.img.threshold(max.maxVal-offset, 255, 'Binary')
+  this.debug('threshold', this.img)
+  return this
+}
+
+ImageProcessor.prototype.erode = function() {
+  var element = cv.imgproc.getStructuringElement(MORPH_RECT, [2, 2] )
+  this.img.erode(1, element)
+  return this
+}
+
+ImageProcessor.prototype.dilate = function() {
+  var element = cv.imgproc.getStructuringElement(MORPH_RECT, [2, 2] )
+  this.img.dilate(1, element)
+  this.debug('dilate', this.img)
+  return this
+}
+
+ImageProcessor.prototype.opening = function() {
+  var element = cv.imgproc.getStructuringElement(MORPH_RECT, [2, 2] )
+  this.img.dilate(1, element)
+  this.img.erode(1, element)
+  this.debug('opening', this.img)
+  return this
+}
+
+ImageProcessor.prototype.closing = function() {
+  var element = cv.imgproc.getStructuringElement(MORPH_RECT, [2, 2] )
+  this.img.erode(1, element)
+  this.img.dilate(1, element)
+  this.debug('closing', this.img)
+  return this
+}
+
+ImageProcessor.prototype.crop = function(x, y, w, h) {
+  this.img = this.img.crop(x*this.img.width(), y*this.img.height(), w*this.img.width(), h*this.img.height())
+  return this
+}
+
+ImageProcessor.prototype.cropAbs = function(x, y, w, h) {
+  this.img = this.img.crop(x, y, w, h)
+  return this
+}
+
+ImageProcessor.prototype.sharpen = function() {
+  var blur = this.img.copy()
+  blur.gaussianBlur([31, 31], 3)
+  this.debug('blur', blur)
+  this.img.addWeighted(this.img, 1.5, blur, -0.5)
+  this.debug('sharpen', this.img)
+  return this
+}
+
+ImageProcessor.prototype.cropLetters = function(size) {
+  var rect = max(detect(this.img, size))
+  if (rect) {
+    this.img = this.img.crop(rect.x, rect.y, rect.width, rect.height)
+  }
+  this.debug('cropletters', this.img)
+  return this
+}
+
+ImageProcessor.prototype.canny = function() {
+  this.img.canny(5, 300)
+  this.debug('canny', this.img)
+  return this
+}
+
+ImageProcessor.prototype.recognize = function(callback) {
+  return new Promise((resolve, reject) => {
+    var buffer = this.img.toBuffer()
+    Tesseract.recognize(buffer, {
+        user_words_file : 'eng',
+        user_words_suffix : 'user-words',
+      })
+      //.progress(p => console.log('progress', p))
+      .catch(err => reject(err))
+      .then(result => {
+        //console.log('result: ', result)
+        try {
+          var t = result.text.trim().replace(/\n/g, ' ')
+          var r = callback ? callback(t) : t
+          resolve(r)
+        } catch (e) {
+          reject(e)
+        }
+      })
+  })
+}
+
+var expireMinutes = function(text) {
+    var time = /(\d{1,2}):(\d{2}):(\d{2})/.exec(text)
+    if (time && time.length == 4) {
+      return ((parseInt(time[1]) * 60) + parseInt(time[2]))
+    } else {
+      throw new Error('could not parse expire time: ' + text)
+    }
+}
+
+var imageTime = function(text) {
+    var time = /(\d{1,2}):(\d{2})(:(\d{2}))?\s*([ap][m])?/i.exec(text)
+    if (time) {
+      var format = 'YYYY-MM-DD ' + 
+                   (time[5] ? 'hh' : 'HH') +
+                   ':mm' +
+                   (time[4] ? ':ss' : '') +
+                   (time[5] ? ' a' : '')
+      var datetime = moment().format('YYYY-MM-DD') + ' ' + time[0]
+      return moment(datetime, format)
+    } else {
+      throw new Error('could not parse image time: ' + text)
+    }
+}
+
+var detect = function(im, size) {
+    var boundRect = []
+    im = im.copy()
+    if (!size) {
+       size = [50, 20]
+    }
+
+    var element = cv.imgproc.getStructuringElement(MORPH_RECT, size)
+    im.dilate(1, element)
+    im.erode(1, element)
+    if (DEBUG) im.save('tmp/morph_close.png')
+    var contours = im.findContours()
+
+    for(var i = 0; i < contours.size(); ++i) {
+      if (contours.cornerCount(i)>20) { 
+        contours.approxPolyDP(i, 3, true)
+        var rect = contours.boundingRect(i)
+        if (rect.width>rect.height) {
+          boundRect.push(rect)
+        }
+      }
+    }
+    return boundRect
+}
+
+var max = function(rects) {
+  var rect = null
+  var area = 0
+  for (i = 0; i < rects.length; ++i) {
+     var a = rects[i].width * rects[i].height
+     if (a > area) {
+       area = a
+       rect = rects[i]
+     }
+  }
+  return rect
+}
+
+var recognizeRect = function(image, rect) {
+  return image.copy().cropAbs(rect.x, 0, rect.width, image.img.height()).debug('notif').recognize(imageTime)
+}
+
+var recognizeRects = function(image, rects, index) {
+  if (!rects || index >= rects.length) return
+
+  return recognizeRect(image, rects[index])
+    .catch(err => {
+      return recognizeRects(image, rects, index + 1)
+    })
+}
+
+var readFile = function(filename) {
+  cv.readImage(filename, function(err, im) {
+    if (err) throw err
+    readImage(im)
+  })
+}
+
+var readImage = function(im) {
+
+  var width = im.width()
+  var height = im.height()
+  if (width < 1 || height < 1) throw new Error('Image has no size')
+
+  var image = new ImageProcessor(im).removeAlpha()
+  var notif = image.copy().crop(0, 0, 1, .036).grayscale()
+  notif.debug('notif', notif.img)
+  var notifTimes = detect(notif.copy(true).canny().img, [10, 2])
+
+  return [
+    image.copy().crop(.20, .052, .792, .065).sharpen().grayscale().blackwhite(40).cropLetters().recognize(), // gym
+    image.copy().crop(0, .234, 1, .091).grayscale().blackwhite().cropLetters().recognize(), // name
+    image.copy().crop(.741, .579, .185, .055).sharpen().grayscale().blackwhite(10).cropLetters([20, 5]).recognize(expireMinutes).catch(err => null), // expire time
+    recognizeRects(notif, notifTimes, 0) // image time
+  ]
+}
+
+ImageProcessor.prototype.debug = function(prefix, img) {
+  if (!img) {
+    img = this.img
+  }
+  if (DEBUG) {
+    img.save('/tmp/' + prefix + this.debugindex + '.png')
+  }
+  return this
+}
+
+var readUrl = function(url) {
+  return new Promise((resolve, reject) => {
+    var stream = new cv.ImageDataStream()
+    stream.on('load', (im) => {
+      Promise.all(readImage(im))
+        .then(results => {
+          resolve({
+            gym : results[0],
+            pokemon : results[1],
+            minutesLeft : results[2],
+            imageTime : results[3]
+          })
+        })
+        .catch(err => reject(err))
+      
+    })
+    request(url).pipe(stream)
+  })
+}
+
+module.exports = {readUrl}

--- a/src/client.js
+++ b/src/client.js
@@ -25,6 +25,10 @@ const getEmoji = (pokemon) => {
 	return '';
 };
 
+const resolve = (cb, message) => {
+	Promise.resolve(message).then(result => cb(result));
+}
+
 client.on('ready', (done) => {
 	client.channels.forEach((channel) => {
 		channelsByName[channel.name] = channel;
@@ -89,8 +93,8 @@ client.on('message', (message, cb) => {
 			message.channel.send(reply);
 			return reply;
 		}
-		if (command === '!raid') {return cb(CHATCOMMANDS.raid(message));}
-		else {return cb(CHATCOMMANDS.egg(message));}
+		if (command === '!raid') {return resolve(cb, CHATCOMMANDS.raid(message));}
+		else {return resolve(cb, CHATCOMMANDS.egg(message));}
 	}
 	//Inside Professor Redwood Channel, Do not touch message.member
 	else if (message.channel.name !== 'professor_redwood') {
@@ -98,10 +102,10 @@ client.on('message', (message, cb) => {
 		return;
 	}
 	
-	if (command === '!breakpoint' || command === '!bp') {return cb(CHATCOMMANDS.breakpoint(message));}
-	else if (command === '!cp') {return cb(CHATCOMMANDS.cp(message));}
-	else if (command === '!counter' || command === '!counters') {return cb(CHATCOMMANDS.counters(message));}
-	else if (command === '!help') {return cb(CHATCOMMANDS.help(message));}
+	if (command === '!breakpoint' || command === '!bp') {return resolve(cb, CHATCOMMANDS.breakpoint(message));}
+	else if (command === '!cp') {return resolve(cb, CHATCOMMANDS.cp(message));}
+	else if (command === '!counter' || command === '!counters') {return resolve(cb, CHATCOMMANDS.counters(message));}
+	else if (command === '!help') {return resolve(cb, CHATCOMMANDS.help(message));}
 
 	//Inside Professor Redwood Channel, OK to touch message.member
 	if (reply === '' && !message.member) {
@@ -109,15 +113,15 @@ client.on('message', (message, cb) => {
 		return;
 	}
 
-	if (command === '!play') {return cb(CHATCOMMANDS.play(message));}
-	else if (command === '!hide') {return cb(CHATCOMMANDS.hide(message));}
-	else if (command === '!team') {return cb(CHATCOMMANDS.team(message));}
-	else if (command === '!want') {return cb(CHATCOMMANDS.want(message));}
-	else if (command === '!reset') {return cb(CHATCOMMANDS.reset(message));}
+	if (command === '!play') {return resolve(cb, CHATCOMMANDS.play(message));}
+	else if (command === '!hide') {return resolve(cb, CHATCOMMANDS.hide(message));}
+	else if (command === '!team') {return resolve(cb, CHATCOMMANDS.team(message));}
+	else if (command === '!want') {return resolve(cb, CHATCOMMANDS.want(message));}
+	else if (command === '!reset') {return resolve(cb, CHATCOMMANDS.reset(message));}
 
 	const errorMessage = 'Command not found: ' + command;
 	CONSTANTS.log(errorMessage);
-	return cb(errorMessage);
+	return resolve(cb, errorMessage);
 });
 
 module.exports = client;


### PR DESCRIPTION
This adds the ability to extract the text (gym, pokemon name, and time remaining) from the raid boss screen. The text extract functionality works for most images but it does have some problems when the raid boss covers the pokemon name. Also, I don't have a discord server so the integration with the discord bot has not been tested.

It uses opencv for image processing. The node-opencv npm module is a wrapper around the native opencv libraries so opencv needs to be installed (I used dnf install opencv opencv-devel on fedora 26). 

It also uses tessaract for text recognition. The npm module is javascript version so no additional libraries are needed.