### PR TITLE
add gen3 mons to !want command, add absol raid boss counters

### DIFF
--- a/data/counters.json
+++ b/data/counters.json
@@ -521,5 +521,26 @@
       "tyranitar":[
          "Bite + Stone Edge"
       ]
+   },
+   "absol":{
+      "stats": {
+         "HP": "?",
+         "CP": "26262"
+      },
+      "fast": ["Snarl", "Psycho Cut"],
+      "charge": ["Dark Pulse", "Megahorn", "Thunder"],
+      "weaknesses": ["Bug", "Fairy", "Fighting"],
+      "resistances": ["Dark", "Ghost", "Psychic(2x)"],
+      "counters": {
+         "Overall": {
+            "machamp": ["Counter + Dynamic Punch"],
+            "hariyama": ["Counter + Dynamic Punch"],
+            "heracross": ["Counter + Dynamic Punch"],
+            "breloom": ["Counter + Dynamic Punch"],
+            "pinsir": ["Bug Bite + X-Scissor"],
+            "blaziken": ["Counter + Overheat"],
+            "scizor": ["Fury Cutter + X-Scissor"]
+         }
+      }
    }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -37,7 +37,7 @@ const data = {
 	MONS: ['aerodactyl', 'chansey', 'ditto', 'dratini', 'farfetch\'d','dragonite', 'girafarig', 'grimer', 'hitmonchan', 'hitmonlee', 'hitmontop',
 		'machop', 'makuhita', 'mareep', 'miltank', 'onix', 'porygon', 'ralts', 'scyther', 'slakoth', 'tauros', 'togetic', 'larvitar', 'unown', 'zangoose'],
 	EGGTIERS: ['tier3', 'tier4', 'tier5'],
-	RAIDMONS: ['alakazam', 'blastoise', 'charizard', 'gengar', 'lapras', 'machamp', 'rhydon', 'snorlax', 'tyranitar', 'venusaur', 'absol', 'mawile'],
+	RAIDMONS: ['absol', 'alakazam', 'blastoise', 'charizard', 'gengar', 'lapras', 'machamp', 'mawile', 'rhydon', 'snorlax', 'tyranitar', 'venusaur'],
 	LEGENDARYMONS: ['legendary', 'articuno', 'moltres', 'zapdos', 'mew', 'mewtwo', 'lugia', 'ho-oh', 'celebi', 'entei', 'raikou', 'suicune'],
 	SPECIALMONS: ['sponsored', 'highiv', 'finalevo'],
 	REGIONS: regionsConfig.regions,

--- a/src/constants.js
+++ b/src/constants.js
@@ -35,9 +35,9 @@ const data = {
 	BOTID: secrets.discord.BOTID,
 	TEAMS: ['valor', 'instinct', 'mystic'],
 	MONS: ['aerodactyl', 'chansey', 'ditto', 'dratini', 'farfetch\'d','dragonite', 'girafarig', 'grimer', 'hitmonchan', 'hitmonlee', 'hitmontop',
-		'machop', 'mareep', 'miltank', 'onix', 'porygon', 'scyther', 'tauros', 'togetic', 'larvitar', 'unown'],
+		'machop', 'makuhita', 'mareep', 'miltank', 'onix', 'porygon', 'ralts', 'scyther', 'slakoth', 'tauros', 'togetic', 'larvitar', 'unown', 'zangoose'],
 	EGGTIERS: ['tier3', 'tier4', 'tier5'],
-	RAIDMONS: ['alakazam', 'blastoise', 'charizard', 'gengar', 'lapras', 'machamp', 'rhydon', 'snorlax', 'tyranitar', 'venusaur'],
+	RAIDMONS: ['alakazam', 'blastoise', 'charizard', 'gengar', 'lapras', 'machamp', 'rhydon', 'snorlax', 'tyranitar', 'venusaur', 'absol', 'mawile'],
 	LEGENDARYMONS: ['legendary', 'articuno', 'moltres', 'zapdos', 'mew', 'mewtwo', 'lugia', 'ho-oh', 'celebi', 'entei', 'raikou', 'suicune'],
 	SPECIALMONS: ['sponsored', 'highiv', 'finalevo'],
 	REGIONS: regionsConfig.regions,
@@ -48,7 +48,8 @@ const data = {
 		'unknown': 'unown',
 		'raiku': 'raikou',
 		'chancey': 'chansey',
-		'tyrannitar': 'tyranitar'
+		'tyrannitar': 'tyranitar',
+		'slakoff': 'slakoth'
 	},
 	NSFW_WORDS: [' fuck ', ' fucking ', ' fuckin ', ' shit ', ' shitty '],
 	PROTECTED_CHANNELS: ['start_here', 'professor_redwood', 'announcements'], // todo : move to a config file


### PR DESCRIPTION
Adds the following gen3 pokemon to the `!want` command:
Makuhita
Ralts
Slakoth
Zangoose
Absol
Mawile

I went ahead and created the roles for the Pokemon in this list that didn't have them.

Also adds raid boss counters for Absol. I couldn't find its raid boss HP but it's only level 4 so that should be fine.